### PR TITLE
Doc: Add psp reference id validation (BREAKING)

### DIFF
--- a/openapi/online.yaml
+++ b/openapi/online.yaml
@@ -1072,6 +1072,7 @@ components:
             will also guarantee uniqueness.
         pspReferenceId:
           minLength: 1
+          maxLength: 50
           type: string
           description: PSP's unique reference to payment.
         amount:


### PR DESCRIPTION
VippsMobilePay platform does not accept references longer than 50 characters or non-ascii.

The only users that breaks with this is ScanPay in SandProd. They'll be informed prior to merging this change.

```json
{
    "code": "",
    "message": "PSPReferenceId: Maximum length of '50' exceeded",
    "correlationId": "6a182349-5a33-466a-a46b-f0a9d319e3d3",
    "origin": "ONL"
}

{
    "code": "",
    "message": "PSPReferenceId: Only ascii charset is supported",
    "correlationId": "a1196fe9-dc7b-40cb-8ffe-e965d989b4ae",
    "origin": "ONL"
}
```